### PR TITLE
Add paired pathology dataset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ Results (jpeg and gif files) will be saved into `generated-images` directory, an
   <img src="files-for-readme/sprite_ani.gif" width="45%" />
 </p>
 
+### Paired Stain Dataset
+To train on a paired dataset located at `E:/patches` containing `stained` and `unstained` folders:
+~~~
+python3 train.py --dataset-name paired --dataset-path E:/patches
+~~~
+
+This will learn to generate stained images conditioned on their unstained counterparts.
+

--- a/train.py
+++ b/train.py
@@ -15,6 +15,7 @@ def parse_arguments():
     parser.add_argument("--timesteps", type=int, default=500, help="Timesteps T for DDPM training")
     parser.add_argument("--beta1", type=float, default=0.0001, help="Hyperparameter for DDPM")
     parser.add_argument("--beta2", type=float, default=0.02, help="Hyperparameter for DDPM training")
+    parser.add_argument("--dataset-path", type=str, default=None, help="Path to custom dataset root")
     parser.add_argument("--checkpoint-save-dir", type=str, default=None, help="Directory to save checkpoints")
     parser.add_argument("--image-save-dir", type=str, default=None, help="Directory to save generated images during training")
     return parser.parse_args()
@@ -22,8 +23,9 @@ def parse_arguments():
 
 if __name__=="__main__":
     args = parse_arguments()
-    diffusion_model = DiffusionModel(device=args.device, dataset_name=args.dataset_name, 
-                                     checkpoint_name=args.checkpoint_name)
+    diffusion_model = DiffusionModel(device=args.device, dataset_name=args.dataset_name,
+                                     checkpoint_name=args.checkpoint_name,
+                                     dataset_path=args.dataset_path)
     diffusion_model.train(batch_size=args.batch_size, n_epoch=args.epochs, lr=args.lr,
                           timesteps=args.timesteps, beta1=args.beta1, beta2=args.beta2,
                           checkpoint_save_dir=args.checkpoint_save_dir, image_save_dir=args.image_save_dir)

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,8 @@ import torch
 import numpy as np
 from torch.utils.data import Dataset
 from torchvision.utils import make_grid
+from torchvision import transforms as T
+from PIL import Image
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 import os
@@ -23,6 +25,41 @@ class SpriteDataset(Dataset):
 
     def __len__(self):
         return len(self.images)
+
+
+class PairedImageDataset(Dataset):
+    """Dataset class for paired images.
+    Expects two subdirectories ``stained`` and ``unstained`` under ``root``.
+    Images with the same file name are assumed to be pairs.
+    """
+
+    def __init__(self, root, transform=None):
+        self.stained_dir = os.path.join(root, "stained")
+        self.unstained_dir = os.path.join(root, "unstained")
+
+        self.stain_paths = sorted([os.path.join(self.stained_dir, f)
+                                   for f in os.listdir(self.stained_dir)
+                                   if not f.startswith('.')])
+        self.unstain_paths = sorted([os.path.join(self.unstained_dir, f)
+                                     for f in os.listdir(self.unstained_dir)
+                                     if not f.startswith('.')])
+        assert len(self.stain_paths) == len(self.unstain_paths), "Mismatched dataset sizes"
+
+        self.transform = transform or T.Compose([
+            T.ToTensor(),
+            lambda x: 2 * x - 1
+        ])
+
+    def __len__(self):
+        return len(self.stain_paths)
+
+    def __getitem__(self, idx):
+        stain = Image.open(self.stain_paths[idx]).convert('RGB')
+        unstain = Image.open(self.unstain_paths[idx]).convert('RGB')
+
+        stain = self.transform(stain)
+        unstain = self.transform(unstain)
+        return stain, unstain
 
 def generate_animation(intermediate_samples, t_steps, fname, n_images_per_row=8):
     """Generates animation and saves as a gif file for given intermediate samples"""


### PR DESCRIPTION
## Summary
- support paired stain dataset by adding `PairedImageDataset`
- allow providing dataset path via `--dataset-path`
- compute image properties for custom dataset
- store dataset properties in checkpoints
- document training on custom paired images

## Testing
- `python -m py_compile diffusion_model.py train.py utils.py models.py sample.py`

------
https://chatgpt.com/codex/tasks/task_e_684eb79eb87c8332b1d47b9bb1cf2a3c