### PR TITLE
Add image resize option

### DIFF
--- a/train.py
+++ b/train.py
@@ -16,6 +16,7 @@ def parse_arguments():
     parser.add_argument("--beta1", type=float, default=0.0001, help="Hyperparameter for DDPM")
     parser.add_argument("--beta2", type=float, default=0.02, help="Hyperparameter for DDPM training")
     parser.add_argument("--dataset-path", type=str, default=None, help="Path to custom dataset root")
+    parser.add_argument("--image-size", type=int, default=None, help="Resize images to this size before training")
     parser.add_argument("--checkpoint-save-dir", type=str, default=None, help="Directory to save checkpoints")
     parser.add_argument("--image-save-dir", type=str, default=None, help="Directory to save generated images during training")
     return parser.parse_args()
@@ -25,7 +26,8 @@ if __name__=="__main__":
     args = parse_arguments()
     diffusion_model = DiffusionModel(device=args.device, dataset_name=args.dataset_name,
                                      checkpoint_name=args.checkpoint_name,
-                                     dataset_path=args.dataset_path)
+                                     dataset_path=args.dataset_path,
+                                     image_size=args.image_size)
     diffusion_model.train(batch_size=args.batch_size, n_epoch=args.epochs, lr=args.lr,
                           timesteps=args.timesteps, beta1=args.beta1, beta2=args.beta2,
                           checkpoint_save_dir=args.checkpoint_save_dir, image_save_dir=args.image_save_dir)


### PR DESCRIPTION
## Summary
- add `--image-size` argument to train script
- allow resizing dataset images and adjust model dimensions accordingly

## Testing
- `python -m py_compile train.py diffusion_model.py`
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684ebdd40aac8332a332d6eeda2586e9